### PR TITLE
tls: fix opaque struct definitions

### DIFF
--- a/src/tls.rs
+++ b/src/tls.rs
@@ -49,16 +49,20 @@ const TLS1_3_VERSION: u16 = 0x0304;
 const TLS_ALERT_ERROR: u16 = 0x100;
 
 #[allow(non_camel_case_types)]
-enum SSL_METHOD {}
+#[repr(transparent)]
+struct SSL_METHOD(c_void);
 
 #[allow(non_camel_case_types)]
-enum SSL_CTX {}
+#[repr(transparent)]
+struct SSL_CTX(c_void);
 
 #[allow(non_camel_case_types)]
-enum SSL {}
+#[repr(transparent)]
+struct SSL(c_void);
 
 #[allow(non_camel_case_types)]
-enum SSL_CIPHER {}
+#[repr(transparent)]
+struct SSL_CIPHER(c_void);
 
 #[repr(C)]
 #[allow(non_camel_case_types)]

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -28,7 +28,7 @@ use std::ffi;
 use std::ptr;
 use std::slice;
 
-use libc;
+use libc::c_void;
 
 use ::Connection;
 
@@ -178,7 +178,7 @@ impl State {
 
     pub fn set_ex_data<T>(&self, idx: i32, data: &T) -> Result<()> {
         map_result(unsafe {
-            let ptr = data as *const T as *const libc::c_void;
+            let ptr = data as *const T as *const c_void;
             SSL_set_ex_data(self.as_ptr(), idx, ptr)
         })
     }
@@ -485,9 +485,9 @@ extern {
     fn SSL_CTX_set_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 
     // SSL
-    fn SSL_get_ex_new_index(argl: libc::c_long, argp: *const libc::c_void,
-        unused: *const libc::c_void, dup_unused: *const libc::c_void,
-        free_func: *const libc::c_void) -> i32;
+    fn SSL_get_ex_new_index(argl: libc::c_long, argp: *const c_void,
+        unused: *const c_void, dup_unused: *const c_void,
+        free_func: *const c_void) -> i32;
 
     fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
 
@@ -496,8 +496,8 @@ extern {
     fn SSL_set_accept_state(ssl: *mut SSL);
     fn SSL_set_connect_state(ssl: *mut SSL);
 
-    fn SSL_set_ex_data(ssl: *mut SSL, idx: i32, ptr: *const libc::c_void) -> i32;
-    fn SSL_get_ex_data(ssl: *mut SSL, idx: i32) -> *mut libc::c_void;
+    fn SSL_set_ex_data(ssl: *mut SSL, idx: i32, ptr: *const c_void) -> i32;
+    fn SSL_get_ex_data(ssl: *mut SSL, idx: i32) -> *mut c_void;
 
     fn SSL_get_pending_cipher(ssl: *mut SSL) -> *const SSL_CIPHER;
 


### PR DESCRIPTION
Using uninhabited enums for opaque types is actually a bad idea, since compiler can rely on them being, well, uninhabited, and it's easy to run into UB.

There are various other approaches to represent them, and I chose to wrap newtype around `c_void`.