### PR TITLE
ffi: export setter functions for config params

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -235,7 +235,10 @@ int main(int argc, char *argv[]) {
     quiche_config_set_idle_timeout(config, 30);
     quiche_config_set_initial_max_data(config, 10000000);
     quiche_config_set_initial_max_stream_data_bidi_local(config, 1000000);
+    quiche_config_set_initial_max_stream_data_uni(config, 1000000);
     quiche_config_set_initial_max_streams_bidi(config, 100);
+    quiche_config_set_initial_max_streams_uni(config, 100);
+    quiche_config_set_disable_migration(config, true);
 
     uint8_t scid[LOCAL_CONN_ID_LEN];
     int rng = open("/dev/urandom", O_RDONLY);

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -115,16 +115,16 @@ void quiche_config_set_initial_max_stream_data_uni(quiche_config *config, uint64
 void quiche_config_set_initial_max_data(quiche_config *config, uint64_t v);
 
 // Sets the `initial_max_streams_bidi` transport parameter.
-void quiche_config_set_initial_max_streams_bidi(quiche_config *config, uint16_t v);
+void quiche_config_set_initial_max_streams_bidi(quiche_config *config, uint64_t v);
 
 // Sets the `initial_max_streams_uni` transport parameter.
-void quiche_config_set_initial_max_streams_uni(quiche_config *config, uint16_t v);
+void quiche_config_set_initial_max_streams_uni(quiche_config *config, uint64_t v);
 
 // Sets the `ack_delay_exponent` transport parameter.
-void quiche_config_set_ack_delay_exponent(quiche_config *config, uint16_t v);
+void quiche_config_set_ack_delay_exponent(quiche_config *config, uint64_t v);
 
 // Sets the `max_ack_delay` transport parameter.
-void quiche_config_set_max_ack_delay(quiche_config *config, uint16_t v);
+void quiche_config_set_max_ack_delay(quiche_config *config, uint64_t v);
 
 // Sets the `disable_migration` transport parameter.
 void quiche_config_set_disable_migration(quiche_config *config, bool v);

--- a/include/quiche.h
+++ b/include/quiche.h
@@ -93,14 +93,14 @@ int quiche_config_load_cert_chain_from_pem_file(quiche_config *config,
 int quiche_config_load_priv_key_from_pem_file(quiche_config *config,
                                               const char *path);
 
+// Configures whether to verify the peer's certificate.
+void quiche_config_verify_peer(quiche_config *config, bool v);
+
 // Enables logging of secrets.
 void quiche_config_log_keys(quiche_config *config);
 
 // Sets the `idle_timeout` transport parameter.
 void quiche_config_set_idle_timeout(quiche_config *config, uint64_t v);
-
-// Sets the `initial_max_data` transport parameter.
-void quiche_config_set_initial_max_data(quiche_config *config, uint64_t v);
 
 // Sets the `initial_max_stream_data_bidi_local` transport parameter.
 void quiche_config_set_initial_max_stream_data_bidi_local(quiche_config *config, uint64_t v);
@@ -108,8 +108,26 @@ void quiche_config_set_initial_max_stream_data_bidi_local(quiche_config *config,
 // Sets the `initial_max_stream_data_bidi_remote` transport parameter.
 void quiche_config_set_initial_max_stream_data_bidi_remote(quiche_config *config, uint64_t v);
 
+// Sets the `initial_max_stream_data_uni` transport parameter.
+void quiche_config_set_initial_max_stream_data_uni(quiche_config *config, uint64_t v);
+
+// Sets the `initial_max_data` transport parameter.
+void quiche_config_set_initial_max_data(quiche_config *config, uint64_t v);
+
 // Sets the `initial_max_streams_bidi` transport parameter.
 void quiche_config_set_initial_max_streams_bidi(quiche_config *config, uint16_t v);
+
+// Sets the `initial_max_streams_uni` transport parameter.
+void quiche_config_set_initial_max_streams_uni(quiche_config *config, uint16_t v);
+
+// Sets the `ack_delay_exponent` transport parameter.
+void quiche_config_set_ack_delay_exponent(quiche_config *config, uint16_t v);
+
+// Sets the `max_ack_delay` transport parameter.
+void quiche_config_set_max_ack_delay(quiche_config *config, uint16_t v);
+
+// Sets the `disable_migration` transport parameter.
+void quiche_config_set_disable_migration(quiche_config *config, bool v);
 
 // Frees the config object.
 void quiche_config_free(quiche_config *config);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -102,6 +102,11 @@ pub extern fn quiche_config_load_priv_key_from_pem_file(config: &mut Config,
 }
 
 #[no_mangle]
+pub extern fn quiche_config_verify_peer(config: &mut Config, v: bool) {
+    config.verify_peer(v);
+}
+
+#[no_mangle]
 pub extern fn quiche_config_log_keys(config: &mut Config) {
     config.log_keys();
 }
@@ -122,6 +127,11 @@ pub extern fn quiche_config_set_initial_max_stream_data_bidi_remote(config: &mut
 }
 
 #[no_mangle]
+pub extern fn quiche_config_set_initial_max_stream_data_uni(config: &mut Config, v: u64) {
+    config.set_initial_max_stream_data_uni(v);
+}
+
+#[no_mangle]
 pub extern fn quiche_config_set_initial_max_data(config: &mut Config, v: u64) {
     config.set_initial_max_data(v);
 }
@@ -129,6 +139,26 @@ pub extern fn quiche_config_set_initial_max_data(config: &mut Config, v: u64) {
 #[no_mangle]
 pub extern fn quiche_config_set_initial_max_streams_bidi(config: &mut Config, v: u64) {
     config.set_initial_max_streams_bidi(v);
+}
+
+#[no_mangle]
+pub extern fn quiche_config_set_initial_max_streams_uni(config: &mut Config, v: u64) {
+    config.set_initial_max_streams_uni(v);
+}
+
+#[no_mangle]
+pub extern fn quiche_config_set_ack_delay_exponent(config: &mut Config, v: u64) {
+    config.set_ack_delay_exponent(v);
+}
+
+#[no_mangle]
+pub extern fn quiche_config_set_max_ack_delay(config: &mut Config, v: u64) {
+    config.set_max_ack_delay(v);
+}
+
+#[no_mangle]
+pub extern fn quiche_config_set_disable_migration(config: &mut Config, v: bool) {
+    config.set_disable_migration(v);
 }
 
 #[no_mangle]


### PR DESCRIPTION
There were transport parameters that were not able to be set :(

This fixes that